### PR TITLE
Fix typo 'absolutly'

### DIFF
--- a/drivers/ide/cy82c693.c
+++ b/drivers/ide/cy82c693.c
@@ -183,7 +183,7 @@ static void cy82c693_set_dma_mode(ide_drive_t *drive, const u8 mode)
 
 	/*
 	 * note: below we set the value for Bus Master IDE TimeOut Register
-	 * I'm not absolutly sure what this does, but it solved my problem
+	 * I'm not absolutely sure what this does, but it solved my problem
 	 * with IDE DMA and sound, so I now can play sound and work with
 	 * my IDE driver at the same time :-)
 	 *


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'absolutely', you typed 'absolutly'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            